### PR TITLE
Feature/3.5.5

### DIFF
--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
@@ -762,8 +762,9 @@ public class ApproovService {
      * Gets the last ARC (Attestation Response Code) code.
      *
      * Always resolves with a string (ARC or empty string).
-     *
-     * @return String ARC from last attestation request or empty string
+     * NOTE: You MUST only call this method upon succesfull attestation completion. Any networking
+     * errors returned from the service layer will not return a meaningful ARC code if the method is called!!!
+     * @return String ARC from last attestation request or empty string if network unavailable
      */
     public static String getLastARC() {
         // Get the dynamic pins from Approov

--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
@@ -811,8 +811,7 @@ public class ApproovService {
      *
      * @param attrs is the signed JWT holding the new install attributes
      * @return void
-     * @throws IllegalArgumentException if the attrs parameter is invalid
-     * @throws IllegalStateException if the Approov SDK is not initialized
+     * @throws ApproovException if the attrs parameter is invalid or the SDK is not initialized
      */
     public static void setInstallAttrsInToken(String attrs) {
         try {
@@ -820,8 +819,10 @@ public class ApproovService {
             Log.d(TAG, "setInstallAttrsInToken");
         } catch (IllegalArgumentException e) {
             Log.e(TAG, "setInstallAttrsInToken failed with IllegalArgument: " + e.getMessage());
+            throw new ApproovException(e);
         } catch (IllegalStateException e) {
             Log.e(TAG, "setInstallAttrsInToken failed with IllegalState: " + e.getMessage());
+            throw new ApproovException(e);
         }
     }
 

--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
@@ -782,19 +782,15 @@ public class ApproovService {
         }
         if (hostname != null) {
             try {
-                Approov.fetchApproovToken(new Approov.TokenFetchCallback() {
-                    @Override
-                    public void approovCallback(Approov.TokenFetchResult result) {
-                        if (result.getToken() != null && !result.getToken().isEmpty()) {
-                            String arc = result.getARC();
-                            if (arc != null) {
-                                return arc;
-                            }
-                        }
-                        Log.i(TAG, "ApproovService: ARC code unavailable");
-                        return "";
+                Approov.TokenFetchResult result = Approov.fetchApproovTokenAndWait(hostname);
+                if (result.getToken() != null && !result.getToken().isEmpty()) {
+                    String arc = result.getARC();
+                    if (arc != null) {
+                        return arc;
                     }
-                }, hostname);
+                }
+                Log.i(TAG, "ApproovService: ARC code unavailable");
+                return "";
             } catch (Exception e) {
                 Log.e(TAG, "ApproovService: error fetching ARC", e);
                 return "";
@@ -803,7 +799,6 @@ public class ApproovService {
             Log.i(TAG, "ApproovService: ARC code unavailable");
             return "";
         }
-        return "";
     }
 
     /**

--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
@@ -813,7 +813,7 @@ public class ApproovService {
      * @return void
      * @throws ApproovException if the attrs parameter is invalid or the SDK is not initialized
      */
-    public static void setInstallAttrsInToken(String attrs) {
+    public static void setInstallAttrsInToken(String attrs) throws ApproovException {
         try {
             Approov.setInstallAttrsInToken(attrs);
             Log.d(TAG, "setInstallAttrsInToken");


### PR DESCRIPTION
Add arc code access from client upon rejection. NOTE: the getLastARC method is to be used only if there is a rejection from the API back end and actual network connection otherwise is empty.