### PR TITLE
Add stale protection refresh at the network layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+- Stale protection refresh: a new network interceptor detects requests that were held between Approov protection being applied and actual transmission (for example by a device deep sleep or doze period, or an app-level request queueing/backoff mechanism) and refreshes the Approov token and any message signature immediately before the request is sent, instead of transmitting expired credentials. Since it operates per network attempt it also refreshes protection on OkHttp generated retries and redirect followups. Configurable via `ApproovService.setStaleProtectionRefreshPeriod()` (default 3000ms, `<=0` disables). Because a refresh reinvokes the mutator's `handleInterceptorProcessedRequest` callback, it is gated on the new `ApproovServiceMutator.supportsProtectionRefresh()` capability: the default mutator and `ApproovDefaultMessageSigning` support it, while custom mutator implementations are never reinvoked unless they opt in.
+
 ## [3.5.7] - 2026-04-09
 
 ### Added

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -326,6 +326,19 @@ void setBindingHeader(String header)
 fun setBindingHeader(header: String)
 ```
 
+## setStaleProtectionRefreshPeriod
+Sets the period in milliseconds after which a request that was held between having its Approov protection applied and being actually transmitted has that protection (Approov token and any message signature) refreshed at the network layer immediately before transmission. Requests may be held in this way if the device enters a deep sleep or doze state while the request is in flight, or if the app employs its own request queueing or backoff mechanism; the Approov token and any message signature (which carries created/expires timestamps) may then have expired by the time the request is sent. A refresh reissues the Approov token fetch (usually satisfied instantly from the SDK's cache) and reapplies any message signing via the service mutator's `handleInterceptorProcessedRequest` callback. Because this reinvokes the callback, a refresh is only performed if the mutator's `supportsProtectionRefresh()` returns true: the default mutator and `ApproovDefaultMessageSigning` support it, while custom `ApproovServiceMutator` implementations must opt in by overriding `supportsProtectionRefresh()` once their callback is safe to invoke more than once per request. The period should be comfortably less than the message signature expiry (15 seconds by default) but high enough that ordinary requests are not reprocessed. The default is 3000ms and passing a value less than or equal to zero disables the refresh.
+
+**Java:**
+```Java
+void setStaleProtectionRefreshPeriod(long periodMS)
+```
+
+**Kotlin:**
+```kotlin
+fun setStaleProtectionRefreshPeriod(periodMS: Long)
+```
+
 ## addSubstitutionHeader
 Adds the name of a `header` which should be subject to [secure strings](https://approov.io/docs/latest/approov-usage-documentation/#secure-strings) substitution. This means that if the `header` is present then the value will be used as a key to look up a secure string value which will be substituted into the `header` value instead. This allows easy migration to the use of secure strings. A `requiredPrefix` may be specified to deal with cases such as the use of "`Bearer `" prefixed before values in an authorization header. Set `requiredPrefix` to `null` if it is not required.
 

--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovDefaultMessageSigning.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovDefaultMessageSigning.java
@@ -195,6 +195,19 @@ public class ApproovDefaultMessageSigning implements ApproovServiceMutator {
     }
 
     /**
+     * The default message signing only ever sets its headers with replace
+     * semantics and regenerates the signature from the current request state,
+     * so it is safe for the stale protection refresh to invoke
+     * handleInterceptorProcessedRequest again.
+     *
+     * @return true as reinvocation is supported
+     */
+    @Override
+    public boolean supportsProtectionRefresh() {
+        return true;
+    }
+
+    /**
      * @deprecated Use ApproovServiceMutator.handleInterceptorProcessedRequest
      *             instead.
      *

--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovRequestFreshness.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovRequestFreshness.java
@@ -1,0 +1,138 @@
+//
+// MIT License
+//
+// Copyright (c) 2016-present, Approov Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package io.approov.service.okhttp;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import okhttp3.Request;
+
+/**
+ * ApproovRequestFreshness is attached as a tag to requests that have been given
+ * Approov protection (token and, optionally, a message signature) so that the
+ * time the protection was applied can be checked again at the network layer,
+ * immediately before the request is transmitted. A request may be held between
+ * protection and transmission, most notably if the device enters a deep sleep
+ * or doze state while the request is queued, or if the app holds requests in a
+ * retry/backoff mechanism. In that case the Approov token, and any message
+ * signature (which carries created/expires timestamps), may no longer be valid
+ * by the time the request is sent and the protection must be refreshed.
+ */
+class ApproovRequestFreshness {
+    // the URL string that was used for the Approov token fetch
+    private final String fetchURL;
+
+    // the mutations that were applied to the request by the Approov interceptor,
+    // required to reapply protection to the request
+    private final ApproovRequestMutations changes;
+
+    // elapsed realtime (which advances during device sleep) at the point the
+    // protection was applied, or -1 if protection has not yet been marked
+    private volatile long protectedAtMillis;
+
+    // names of the headers that were added by the mutator's processed request
+    // callback (normally the message signature headers) which must be removed
+    // before the protection can be reapplied
+    private volatile List<String> mutatorAddedHeaders;
+
+    /**
+     * Constructs a freshness marker for a request being given Approov protection.
+     *
+     * @param fetchURL the URL string used for the Approov token fetch
+     * @param changes  the mutations applied to the request by the interceptor
+     */
+    ApproovRequestFreshness(String fetchURL, ApproovRequestMutations changes) {
+        this.fetchURL = fetchURL;
+        this.changes = changes;
+        this.protectedAtMillis = -1;
+        this.mutatorAddedHeaders = Collections.emptyList();
+    }
+
+    /**
+     * Gets the URL string that was used for the Approov token fetch.
+     *
+     * @return the token fetch URL string
+     */
+    String getFetchURL() {
+        return fetchURL;
+    }
+
+    /**
+     * Gets the mutations that were applied to the request by the interceptor.
+     *
+     * @return the request mutations
+     */
+    ApproovRequestMutations getChanges() {
+        return changes;
+    }
+
+    /**
+     * Gets the elapsed realtime at which the protection was last applied.
+     *
+     * @return the elapsed realtime in milliseconds, or -1 if not yet marked
+     */
+    long getProtectedAtMillis() {
+        return protectedAtMillis;
+    }
+
+    /**
+     * Gets the names of the headers that were added by the mutator's processed
+     * request callback when the protection was last applied.
+     *
+     * @return the list of header names, which may be empty
+     */
+    List<String> getMutatorAddedHeaders() {
+        return mutatorAddedHeaders;
+    }
+
+    /**
+     * Marks the request as protected at the given time, recording the headers
+     * added by the mutator's processed request callback so that they can be
+     * removed if the protection needs to be reapplied later.
+     *
+     * @param protectedAtMillis   the elapsed realtime in milliseconds
+     * @param mutatorAddedHeaders the names of headers added by the mutator
+     */
+    void markProtected(long protectedAtMillis, List<String> mutatorAddedHeaders) {
+        this.protectedAtMillis = protectedAtMillis;
+        this.mutatorAddedHeaders = mutatorAddedHeaders;
+    }
+
+    /**
+     * Computes the names of the headers present in the after request that were
+     * not present in the before request. Header name comparison is case
+     * insensitive.
+     *
+     * @param before the request prior to the mutator's processed request callback
+     * @param after  the request returned by the callback
+     * @return the list of header names added by the callback, which may be empty
+     */
+    static List<String> addedHeaderNames(Request before, Request after) {
+        // names() provides a set ordered with a case insensitive comparator so
+        // that the contains check is also case insensitive
+        Set<String> beforeNames = before.headers().names();
+        List<String> added = new ArrayList<>();
+        for (String name : after.headers().names()) {
+            if (!beforeNames.contains(name))
+                added.add(name);
+        }
+        return added;
+    }
+}

--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovService.java
@@ -19,6 +19,7 @@ package io.approov.service.okhttp;
 
 import android.util.Log;
 import android.content.Context;
+import android.os.SystemClock;
 import androidx.annotation.VisibleForTesting;
 
 import com.criticalblue.approovsdk.Approov;
@@ -74,6 +75,13 @@ public class ApproovService {
     // name for the default builder
     private static final String DEFAULT_BUILDER_NAME = "_default";
 
+    // default period in milliseconds after which a request that has been held
+    // between Approov protection being applied and actual transmission (such as by
+    // a device deep sleep or doze period) has its protection refreshed at the
+    // network layer before being sent - this must be comfortably less than both
+    // the Approov token lifetime and the default message signature expiry (15s)
+    private static final long DEFAULT_STALE_PROTECTION_REFRESH_MS = 3000;
+
     // true if the Approov SDK initialized okay
     private static boolean isInitialized = false;
 
@@ -106,6 +114,11 @@ public class ApproovService {
 
     // any header to be used for binding in Approov tokens or null if not set
     private static String bindingHeader = null;
+
+    // period in milliseconds after which a request held between protection and
+    // transmission has its Approov protection refreshed at the network layer, or
+    // <=0 if stale protection refresh is disabled
+    private static long staleProtectionRefreshMS = DEFAULT_STALE_PROTECTION_REFRESH_MS;
 
     // The mutator instance used to control ApproovService behavior at key points in
     // the flow.
@@ -177,6 +190,7 @@ public class ApproovService {
         approovTraceIDHeader = APPROOV_TRACE_ID_HEADER;
         approovTokenPrefix = APPROOV_TOKEN_PREFIX;
         bindingHeader = null;
+        staleProtectionRefreshMS = DEFAULT_STALE_PROTECTION_REFRESH_MS;
         serviceMutator = ApproovServiceMutator.DEFAULT;
         substitutionHeaders = new HashMap<>();
         substitutionQueryParams = new HashMap<>();
@@ -238,6 +252,7 @@ public class ApproovService {
         approovTraceIDHeader = null;
         approovTokenPrefix = APPROOV_TOKEN_PREFIX;
         bindingHeader = null;
+        staleProtectionRefreshMS = DEFAULT_STALE_PROTECTION_REFRESH_MS;
         serviceMutator = ApproovServiceMutator.DEFAULT;
         substitutionHeaders = null;
         substitutionQueryParams = null;
@@ -385,6 +400,47 @@ public class ApproovService {
     }
 
     /**
+     * Builds the value to be used for the Approov token header from a token
+     * fetch result, accounting for the option to use the fetch status as the
+     * value when no actual token is available.
+     *
+     * @param approovResults the token fetch result
+     * @return the value to set on the Approov token header
+     */
+    static String buildTokenHeaderValue(Approov.TokenFetchResult approovResults) {
+        if (approovResults.getToken().isEmpty() && getUseApproovStatusIfNoToken())
+            return getApproovTokenPrefix() + approovResults.getStatus().toString();
+        return getApproovTokenPrefix() + approovResults.getToken();
+    }
+
+    /**
+     * Updates the data hash for token binding from any binding header present
+     * on the given request, ahead of a token fetch. The binding header
+     * presence is optional.
+     *
+     * @param request the request that may carry the binding header
+     */
+    static void updateBindingDataHash(Request request) {
+        String bindingHeader = getBindingHeader();
+        if ((bindingHeader != null) && request.headers().names().contains(bindingHeader))
+            Approov.setDataHashInToken(request.header(bindingHeader));
+    }
+
+    /**
+     * Forces a pinning rebuild if the given token fetch result indicates that
+     * there was a dynamic configuration update.
+     *
+     * @param approovResults the token fetch result
+     */
+    static void updatePinsIfConfigChanged(Approov.TokenFetchResult approovResults) {
+        if (approovResults.isConfigChanged()) {
+            Approov.fetchConfig();
+            rebuildPins();
+            Log.d(TAG, "Dynamic configuration updated");
+        }
+    }
+
+    /**
      * Sets a binding header that must be present on all requests using the Approov
      * service. A
      * header should be chosen whose value is unchanging for most requests (such as
@@ -409,6 +465,41 @@ public class ApproovService {
      */
     static synchronized String getBindingHeader() {
         return bindingHeader;
+    }
+
+    /**
+     * Sets the period after which a request that was held between having its
+     * Approov protection applied and being actually transmitted has that
+     * protection (Approov token and any message signature) refreshed at the
+     * network layer immediately before transmission. Requests may be held in
+     * this way if the device enters a deep sleep or doze state while the
+     * request is in flight, or if the app employs its own request queueing or
+     * backoff mechanism. Note that such a refresh reissues the Approov token
+     * fetch (usually satisfied instantly from the SDK's cache) and reapplies
+     * any message signing by reinvoking the service mutator's processed
+     * request callback, so it is only performed if the mutator's
+     * supportsProtectionRefresh() indicates that this is safe (true for the
+     * default mutator and ApproovDefaultMessageSigning, false for custom
+     * mutators unless they opt in). The period should be comfortably less than the
+     * message signature expiry (15 seconds by default) but high enough that
+     * ordinary requests are not reprocessed. The default is 3000ms.
+     *
+     * @param periodMS refresh threshold in milliseconds, or <=0 to disable
+     *                 stale protection refresh
+     */
+    public static synchronized void setStaleProtectionRefreshPeriod(long periodMS) {
+        Log.d(TAG, "setStaleProtectionRefreshPeriod " + periodMS);
+        staleProtectionRefreshMS = periodMS;
+    }
+
+    /**
+     * Gets the period after which a held request has its Approov protection
+     * refreshed at the network layer before transmission.
+     *
+     * @return refresh threshold in milliseconds, or <=0 if disabled
+     */
+    static synchronized long getStaleProtectionRefreshPeriod() {
+        return staleProtectionRefreshMS;
     }
 
     /**
@@ -1154,12 +1245,14 @@ public class ApproovService {
                         iter.remove();
                 }
 
-                // remove any existing ApproovPinningInterceptor from the builder
+                // remove any existing ApproovFreshnessInterceptor or
+                // ApproovPinningInterceptor from the builder
                 interceptors = okHttpBuilder.networkInterceptors();
                 iter = interceptors.iterator();
                 while (iter.hasNext()) {
                     Interceptor interceptor = iter.next();
-                    if (interceptor instanceof ApproovPinningInterceptor)
+                    if ((interceptor instanceof ApproovFreshnessInterceptor) ||
+                            (interceptor instanceof ApproovPinningInterceptor))
                         iter.remove();
                 }
 
@@ -1168,6 +1261,7 @@ public class ApproovService {
                 ApproovTokenInterceptor tokenInterceptor = new ApproovTokenInterceptor();
                 okHttpClient = okHttpBuilder
                         .addInterceptor(tokenInterceptor)
+                        .addNetworkInterceptor(new ApproovFreshnessInterceptor())
                         .addNetworkInterceptor(pinningInterceptor).build();
             } else {
                 // if the ApproovService was not initialized or Approov is bypassed, build a
@@ -1242,9 +1336,7 @@ class ApproovTokenInterceptor implements Interceptor {
         }
 
         // update the data hash based on any token binding header (presence is optional)
-        String bindingHeader = ApproovService.getBindingHeader();
-        if ((bindingHeader != null) && request.headers().names().contains(bindingHeader))
-            Approov.setDataHashInToken(request.header(bindingHeader));
+        ApproovService.updateBindingDataHash(request);
 
         HttpUrl url = request.url();
 
@@ -1259,11 +1351,7 @@ class ApproovTokenInterceptor implements Interceptor {
         Log.d(TAG, "Token for " + url.toString() + ": " + approovResults.getLoggableToken());
 
         // force a pinning rebuild if there is any dynamic config update
-        if (approovResults.isConfigChanged()) {
-            Approov.fetchConfig();
-            ApproovService.rebuildPins();
-            Log.d(TAG, "Dynamic configuration updated");
-        }
+        ApproovService.updatePinsIfConfigChanged(approovResults);
 
         // check the status of Approov token fetch using decision maker
         boolean aChange = false;
@@ -1275,10 +1363,7 @@ class ApproovTokenInterceptor implements Interceptor {
             // we successfully obtained a token so add it to the header for the request
             aChange = true;
             setTokenHeaderKey = ApproovService.getApproovTokenHeader();
-            if ((approovResults.getToken().isEmpty()) && ApproovService.getUseApproovStatusIfNoToken())
-                setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getStatus().toString();
-            else
-                setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getToken();
+            setTokenHeaderValue = ApproovService.buildTokenHeaderValue(approovResults);
 
             String traceIDHeader = ApproovService.getApproovTraceIDHeader();
             String traceID = approovResults.getTraceID();
@@ -1345,11 +1430,18 @@ class ApproovTokenInterceptor implements Interceptor {
         // gather the request changes applied to the request
         ApproovRequestMutations changes = new ApproovRequestMutations();
         // apply all the changes to the request
+        ApproovRequestFreshness freshness = null;
         if (aChange) {
             Request.Builder builder = request.newBuilder();
             if (setTokenHeaderKey != null) {
                 builder.header(setTokenHeaderKey, setTokenHeaderValue);
                 changes.setTokenHeaderKey(setTokenHeaderKey);
+
+                // tag the request so that the freshness interceptor can determine at the
+                // network layer whether the protection was applied too long ago and must
+                // be refreshed before transmission
+                freshness = new ApproovRequestFreshness(url.toString(), changes);
+                builder.tag(ApproovRequestFreshness.class, freshness);
             }
             if (setTraceIDHeaderKey != null) {
                 builder.header(setTraceIDHeaderKey, setTraceIDHeaderValue);
@@ -1370,10 +1462,119 @@ class ApproovTokenInterceptor implements Interceptor {
         }
 
         // call the processed request callback
-        request = mutator.handleInterceptorProcessedRequest(request, changes);
+        Request processedRequest = mutator.handleInterceptorProcessedRequest(request, changes);
+
+        // record the time at which the protection was applied, along with the names
+        // of any headers added by the processed request callback (normally message
+        // signature headers), so that the freshness interceptor can refresh the
+        // protection at the network layer if the request is held too long before
+        // transmission
+        if (freshness != null)
+            freshness.markProtected(SystemClock.elapsedRealtime(),
+                    ApproovRequestFreshness.addedHeaderNames(request, processedRequest));
 
         // proceed with the rest of the chain
-        return chain.proceed(request);
+        return chain.proceed(processedRequest);
+    }
+}
+
+// network interceptor that refreshes the Approov protection (token and any
+// message signature) on requests that were held for too long between the
+// ApproovTokenInterceptor applying the protection and the request actually
+// being transmitted. Requests may be held in this way if the device enters a
+// deep sleep or doze state while the request is queued, or if the app employs
+// its own request queueing or backoff mechanism; the Approov token and any
+// message signature (which carries created/expires timestamps) may then have
+// expired by the time the request is sent. Since this is a network interceptor
+// it runs immediately before transmission for every attempt, including OkHttp
+// generated retries and redirect followups which do not pass through the
+// application layer ApproovTokenInterceptor again.
+class ApproovFreshnessInterceptor implements Interceptor {
+    // logging tag
+    private final static String TAG = "ApproovFreshness";
+
+    /**
+     * Constructs a new interceptor that refreshes stale Approov protection.
+     */
+    public ApproovFreshnessInterceptor() {
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+
+        // only requests given a token by the ApproovTokenInterceptor carry a
+        // freshness marker and are candidates for a refresh
+        ApproovRequestFreshness freshness = request.tag(ApproovRequestFreshness.class);
+        if (freshness == null)
+            return chain.proceed(request);
+
+        // measure how long the request has been held since the protection was
+        // applied, using a clock that advances during device sleep, and proceed
+        // unchanged if within the refresh period or if the refresh is disabled
+        long refreshPeriodMS = ApproovService.getStaleProtectionRefreshPeriod();
+        if ((refreshPeriodMS <= 0) || (freshness.getProtectedAtMillis() < 0))
+            return chain.proceed(request);
+        long heldMS = SystemClock.elapsedRealtime() - freshness.getProtectedAtMillis();
+        if (heldMS <= refreshPeriodMS)
+            return chain.proceed(request);
+
+        // cache the mutator for the duration of the interceptor to make sure
+        // it is not changed mid-flight - a refresh reinvokes the mutator's
+        // processed request callback so it is only performed if the mutator
+        // declares that this is safe
+        ApproovServiceMutator mutator = ApproovService.getServiceMutator();
+        if (!mutator.supportsProtectionRefresh()) {
+            Log.d(TAG, "Request held for " + heldMS + "ms but " + mutator +
+                    " does not support protection refresh");
+            return chain.proceed(request);
+        }
+        Log.d(TAG, "Request held for " + heldMS + "ms since Approov protection was applied, " +
+                "refreshing before transmission");
+
+        // update the data hash based on any token binding header (presence is optional)
+        ApproovService.updateBindingDataHash(request);
+
+        // refetch the Approov token using the URL from the original fetch - if the
+        // cached token is still valid this returns immediately, otherwise a fresh
+        // token is fetched
+        Approov.TokenFetchResult approovResults = Approov.fetchApproovTokenAndWait(freshness.getFetchURL());
+        Log.d(TAG, "Refreshed token for " + freshness.getFetchURL() + ": " + approovResults.getLoggableToken());
+
+        // force a pinning rebuild if there is any dynamic config update
+        ApproovService.updatePinsIfConfigChanged(approovResults);
+
+        // check the status of the Approov token fetch using the decision maker - if
+        // no token is available (but this is not an error) then the request is sent
+        // unchanged
+        if (!mutator.handleInterceptorFetchTokenResult(approovResults, freshness.getFetchURL()))
+            return chain.proceed(request);
+
+        // rebuild the request by removing the headers previously added by the
+        // processed request callback (normally the message signature headers) and
+        // updating the token header with the fresh token
+        ApproovRequestMutations changes = freshness.getChanges();
+        Request.Builder builder = request.newBuilder();
+        for (String header : freshness.getMutatorAddedHeaders())
+            builder.removeHeader(header);
+        builder.header(changes.getTokenHeaderKey(), ApproovService.buildTokenHeaderValue(approovResults));
+        String traceIDHeader = changes.getTraceIDHeaderKey();
+        String traceID = approovResults.getTraceID();
+        if ((traceIDHeader != null) && (traceID != null) && !traceID.isEmpty())
+            builder.header(traceIDHeader, traceID);
+        Request refreshedRequest = builder.build();
+
+        // reapply the processed request callback so that any message signature is
+        // regenerated over the fresh token with new created/expires timestamps
+        Request processedRequest = mutator.handleInterceptorProcessedRequest(refreshedRequest, changes);
+
+        // update the marker so that any subsequent attempts with this request
+        // measure the held time from this refresh
+        freshness.markProtected(SystemClock.elapsedRealtime(),
+                ApproovRequestFreshness.addedHeaderNames(refreshedRequest, processedRequest));
+
+        // proceed with the rest of the chain
+        return chain.proceed(processedRequest);
     }
 }
 

--- a/approov-service/src/main/java/io/approov/service/okhttp/ApproovServiceMutator.java
+++ b/approov-service/src/main/java/io/approov/service/okhttp/ApproovServiceMutator.java
@@ -43,6 +43,13 @@ public interface ApproovServiceMutator {
         public String toString() {
             return "ApproovServiceMutator.DEFAULT";
         }
+
+        @Override
+        public boolean supportsProtectionRefresh() {
+            // the default handleInterceptorProcessedRequest makes no changes so it
+            // is trivially safe to invoke again
+            return true;
+        }
     };
 
     /**
@@ -329,6 +336,28 @@ public interface ApproovServiceMutator {
             throws ApproovException {
         // No further changes to the request are required
         return request;
+    }
+
+    /**
+     * Indicates whether this mutator supports the stale protection refresh
+     * performed at the network layer for requests that were held between having
+     * their Approov protection applied and being actually transmitted (see
+     * ApproovService.setStaleProtectionRefreshPeriod). A refresh removes the
+     * headers previously added by handleInterceptorProcessedRequest, updates
+     * the Approov token header and then invokes
+     * handleInterceptorProcessedRequest again on the same request, so it must
+     * only be enabled for implementations whose callback is safe to invoke
+     * more than once per request (note that changes the callback makes other
+     * than adding headers, such as modifying existing header values in place,
+     * are not undone before the reinvocation). This returns false by default
+     * so that custom implementations are never reinvoked unless they opt in
+     * by overriding this method.
+     *
+     * @return true if the stale protection refresh may reinvoke
+     *         handleInterceptorProcessedRequest, false to prevent any refresh
+     */
+    default boolean supportsProtectionRefresh() {
+        return false;
     }
 
     /**

--- a/approov-service/src/test/java/io/approov/service/okhttp/ApproovServiceMiniSdkTest.java
+++ b/approov-service/src/test/java/io/approov/service/okhttp/ApproovServiceMiniSdkTest.java
@@ -16,9 +16,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowSystemClock;
  
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -884,6 +887,150 @@ public class ApproovServiceMiniSdkTest {
             fail("Expected ApproovException");
         } catch (ApproovException e) {
             // Should throw due to IllegalArgumentException from SDK
+        }
+    }
+
+    // ==================================================================================
+    // Stale Protection Refresh
+    // ==================================================================================
+
+    // message signing mutator that counts processed request callback invocations so
+    // that tests can observe how many times protection was applied to a request
+    private static class CountingMessageSigning extends ApproovDefaultMessageSigning {
+        final AtomicInteger processedCount = new AtomicInteger();
+
+        @Override
+        public Request handleInterceptorProcessedRequest(Request request, ApproovRequestMutations changes)
+                throws ApproovException {
+            processedCount.incrementAndGet();
+            return super.handleInterceptorProcessedRequest(request, changes);
+        }
+    }
+
+    /**
+     * A request that is held between the token interceptor applying protection and
+     * the request being transmitted (simulated by advancing the elapsed realtime
+     * clock in a network interceptor that runs before the Approov freshness
+     * interceptor) must have its protection refreshed at the network layer: the
+     * processed request callback runs a second time and the transmitted request
+     * carries exactly one token and one set of signature headers.
+     */
+    @Test
+    public void testStaleRequestProtectionRefreshedAtNetworkLayer() throws Exception {
+        reinitializeServiceWithTargetHost("");
+
+        CountingMessageSigning signing = new CountingMessageSigning();
+        signing.setDefaultFactory(ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning());
+        ApproovService.setServiceMutator(signing);
+
+        // simulate a device suspend between protection and transmission on the
+        // first network attempt only
+        AtomicInteger attempts = new AtomicInteger();
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+            .addNetworkInterceptor(chain -> {
+                if (attempts.getAndIncrement() == 0)
+                    ShadowSystemClock.advanceBy(Duration.ofSeconds(10));
+                return chain.proceed(chain.request());
+            });
+        ApproovService.setOkHttpClientBuilder(builder);
+
+        OkHttpClient client = ApproovService.getOkHttpClient();
+        Request request = new Request.Builder().url(getTargetURL()).get().build();
+        try (Response response = client.newCall(request).execute()) {
+            JSONObject reply = new JSONObject(response.body().string());
+
+            // protection was applied at the application layer and refreshed once at
+            // the network layer
+            assertEquals(2, signing.processedCount.get());
+
+            // the transmitted request carries a token and exactly one signature
+            assertNotNull(getHeader(reply, "Approov-Token"));
+            String signature = getHeader(reply, "Signature");
+            assertNotNull(signature);
+            assertTrue(signature.startsWith("install="));
+            assertEquals(signature.indexOf("install="), signature.lastIndexOf("install="));
+            String signatureInput = getHeader(reply, "Signature-Input");
+            assertNotNull(signatureInput);
+            assertTrue(signatureInput.startsWith("install="));
+            assertEquals(signatureInput.indexOf("install="), signatureInput.lastIndexOf("install="));
+        }
+    }
+
+    /**
+     * A request that is not held between protection and transmission must not have
+     * its protection refreshed, and disabling the stale protection refresh must
+     * prevent a refresh even for a held request.
+     */
+    @Test
+    public void testProtectionNotRefreshedWhenFreshOrDisabled() throws Exception {
+        reinitializeServiceWithTargetHost("");
+
+        CountingMessageSigning signing = new CountingMessageSigning();
+        signing.setDefaultFactory(ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning());
+        ApproovService.setServiceMutator(signing);
+
+        // a request that is transmitted promptly is not reprocessed
+        OkHttpClient client = ApproovService.getOkHttpClient();
+        Request request = new Request.Builder().url(getTargetURL()).get().build();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            assertEquals(1, signing.processedCount.get());
+        }
+
+        // with the refresh disabled even a held request is not reprocessed
+        ApproovService.setStaleProtectionRefreshPeriod(0);
+        AtomicInteger attempts = new AtomicInteger();
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+            .addNetworkInterceptor(chain -> {
+                if (attempts.getAndIncrement() == 0)
+                    ShadowSystemClock.advanceBy(Duration.ofSeconds(10));
+                return chain.proceed(chain.request());
+            });
+        ApproovService.setOkHttpClientBuilder(builder);
+        client = ApproovService.getOkHttpClient();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            assertEquals(2, signing.processedCount.get());
+        }
+    }
+
+    /**
+     * A custom mutator that does not opt in to protection refresh (via
+     * supportsProtectionRefresh) must never have its processed request callback
+     * reinvoked, even for a held request.
+     */
+    @Test
+    public void testProtectionNotRefreshedForNonOptedInMutator() throws Exception {
+        reinitializeServiceWithTargetHost("");
+
+        // a custom mutator implementing the interface directly, which does not
+        // override supportsProtectionRefresh and so defaults to unsupported
+        AtomicInteger processedCount = new AtomicInteger();
+        ApproovService.setServiceMutator(new ApproovServiceMutator() {
+            @Override
+            public Request handleInterceptorProcessedRequest(Request request, ApproovRequestMutations changes)
+                    throws ApproovException {
+                processedCount.incrementAndGet();
+                return request;
+            }
+        });
+
+        AtomicInteger attempts = new AtomicInteger();
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+            .addNetworkInterceptor(chain -> {
+                if (attempts.getAndIncrement() == 0)
+                    ShadowSystemClock.advanceBy(Duration.ofSeconds(10));
+                return chain.proceed(chain.request());
+            });
+        ApproovService.setOkHttpClientBuilder(builder);
+
+        OkHttpClient client = ApproovService.getOkHttpClient();
+        Request request = new Request.Builder().url(getTargetURL()).get().build();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            assertEquals(1, processedCount.get());
         }
     }
 

--- a/approov-service/src/test/java/io/approov/service/okhttp/FreshnessInterceptorTest.java
+++ b/approov-service/src/test/java/io/approov/service/okhttp/FreshnessInterceptorTest.java
@@ -1,0 +1,201 @@
+package io.approov.service.okhttp;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.*;
+
+import android.os.SystemClock;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Call;
+import okhttp3.Connection;
+import okhttp3.Interceptor;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@RunWith(RobolectricTestRunner.class)
+public class FreshnessInterceptorTest {
+    @Before
+    @After
+    public void resetApproovServiceState() {
+        ApproovService.reset();
+    }
+
+    // minimal chain that records the request it was asked to proceed with
+    private static class FakeChain implements Interceptor.Chain {
+        private final Request request;
+        Request proceededWith;
+
+        FakeChain(Request request) {
+            this.request = request;
+        }
+
+        @Override
+        public Request request() {
+            return request;
+        }
+
+        @Override
+        public Response proceed(Request request) {
+            proceededWith = request;
+            return new Response.Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .build();
+        }
+
+        @Override
+        public Connection connection() {
+            return null;
+        }
+
+        @Override
+        public Call call() {
+            throw new UnsupportedOperationException("call() not supported in FakeChain");
+        }
+
+        @Override
+        public int connectTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Interceptor.Chain withConnectTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int readTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Interceptor.Chain withReadTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+
+        @Override
+        public int writeTimeoutMillis() {
+            return 0;
+        }
+
+        @Override
+        public Interceptor.Chain withWriteTimeout(int timeout, TimeUnit unit) {
+            return this;
+        }
+    }
+
+    @Test
+    public void testAddedHeaderNamesComputesAddedHeaders() {
+        Request before = new Request.Builder()
+                .url("https://api.example.com/")
+                .header("Approov-Token", "token")
+                .header("Content-Type", "application/json")
+                .build();
+        Request after = before.newBuilder()
+                .header("Signature", "sig")
+                .header("Signature-Input", "sig-input")
+                .header("content-type", "application/json")
+                .build();
+        List<String> added = ApproovRequestFreshness.addedHeaderNames(before, after);
+        assertEquals(Arrays.asList("Signature", "Signature-Input"), added);
+    }
+
+    @Test
+    public void testAddedHeaderNamesIsCaseInsensitive() {
+        Request before = new Request.Builder()
+                .url("https://api.example.com/")
+                .header("Approov-Token", "token")
+                .build();
+        Request after = before.newBuilder()
+                .header("APPROOV-TOKEN", "token2")
+                .build();
+        List<String> added = ApproovRequestFreshness.addedHeaderNames(before, after);
+        assertTrue(added.isEmpty());
+    }
+
+    @Test
+    public void testRequestWithoutMarkerProceedsUnchanged() throws IOException {
+        Request request = new Request.Builder().url("https://api.example.com/").build();
+        FakeChain chain = new FakeChain(request);
+        new ApproovFreshnessInterceptor().intercept(chain);
+        assertSame(request, chain.proceededWith);
+    }
+
+    @Test
+    public void testFreshRequestProceedsUnchanged() throws IOException {
+        ApproovRequestFreshness freshness = new ApproovRequestFreshness(
+                "https://api.example.com/", new ApproovRequestMutations());
+        freshness.markProtected(SystemClock.elapsedRealtime(), Arrays.asList("Signature"));
+        Request request = new Request.Builder()
+                .url("https://api.example.com/")
+                .tag(ApproovRequestFreshness.class, freshness)
+                .build();
+        FakeChain chain = new FakeChain(request);
+        new ApproovFreshnessInterceptor().intercept(chain);
+        assertSame(request, chain.proceededWith);
+    }
+
+    @Test
+    public void testStaleRequestProceedsUnchangedWhenRefreshDisabled() throws IOException {
+        ApproovService.setStaleProtectionRefreshPeriod(0);
+        ApproovRequestFreshness freshness = new ApproovRequestFreshness(
+                "https://api.example.com/", new ApproovRequestMutations());
+        freshness.markProtected(SystemClock.elapsedRealtime() - 60000, Arrays.asList("Signature"));
+        Request request = new Request.Builder()
+                .url("https://api.example.com/")
+                .tag(ApproovRequestFreshness.class, freshness)
+                .build();
+        FakeChain chain = new FakeChain(request);
+        new ApproovFreshnessInterceptor().intercept(chain);
+        assertSame(request, chain.proceededWith);
+    }
+
+    @Test
+    public void testUnmarkedProtectionTimeProceedsUnchanged() throws IOException {
+        // a marker that was never marked as protected must not trigger a refresh
+        ApproovRequestFreshness freshness = new ApproovRequestFreshness(
+                "https://api.example.com/", new ApproovRequestMutations());
+        Request request = new Request.Builder()
+                .url("https://api.example.com/")
+                .tag(ApproovRequestFreshness.class, freshness)
+                .build();
+        FakeChain chain = new FakeChain(request);
+        new ApproovFreshnessInterceptor().intercept(chain);
+        assertSame(request, chain.proceededWith);
+    }
+
+    @Test
+    public void testMarkerSurvivesRequestRebuild() {
+        // OkHttp followup requests (redirects, retries) are built with newBuilder()
+        // and must retain the freshness marker
+        ApproovRequestFreshness freshness = new ApproovRequestFreshness(
+                "https://api.example.com/", new ApproovRequestMutations());
+        Request request = new Request.Builder()
+                .url("https://api.example.com/")
+                .tag(ApproovRequestFreshness.class, freshness)
+                .build();
+        Request followup = request.newBuilder().url("https://api.example.com/redirected").build();
+        assertSame(freshness, followup.tag(ApproovRequestFreshness.class));
+    }
+
+    @Test
+    public void testStaleProtectionRefreshPeriodDefaultAndReset() {
+        assertEquals(3000, ApproovService.getStaleProtectionRefreshPeriod());
+        ApproovService.setStaleProtectionRefreshPeriod(10000);
+        assertEquals(10000, ApproovService.getStaleProtectionRefreshPeriod());
+        ApproovService.reset();
+        assertEquals(3000, ApproovService.getStaleProtectionRefreshPeriod());
+    }
+}


### PR DESCRIPTION
Requests may be held between the application-layer ApproovTokenInterceptor applying protection (token and optional message signature) and actual transmission, most notably when the device enters a deep sleep or doze state, or when the app queues requests with its own retry/backoff. The new ApproovFreshnessInterceptor network interceptor detects, immediately before transmission (including OkHttp retries and redirect followups), that the protection was applied longer ago than the configurable stale protection refresh period (default 3000ms, ApproovService.setStaleProtectionRefreshPeriod) and refreshes it: the Approov token is refetched (normally from the SDK cache) and the message signature is regenerated with fresh created/expires timestamps by reinvoking the mutator's processed request callback. The refresh is only performed for mutators that declare it safe via the new ApproovServiceMutator.supportsProtectionRefresh (true for the default mutator and ApproovDefaultMessageSigning, opt-in for custom mutators).